### PR TITLE
Specify the 'engines' field in npm and correct run example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 lighthouse
 .DS_Store
+.idea
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Kick start test execution with the same `cdpPort`.
 npx testcafe chrome:headless:cdpPort=9222 test.js
 
 // non headless mode
-npx testcafe 'chrome --remote-debugging-port=9222'  test.js
+npx testcafe 'chrome:emulation:cdpPort=9222'  test.js
 ```
 
 ## Thresholds per tests

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/abhinaba-ghosh/testcafe-lighthouse"
   },
+  "engines": {
+    "node": ">=10.x"
+  },
   "keywords": [
     "testcafe",
     "testcafe-lighthouse",


### PR DESCRIPTION
TestCafe supports the `10.x` version of Node.js. The `testcafe-lighthouse` module is written using the `export/import` statements, which are not supported in `10.x` version. 
So, I restricted the minimal supported version of Node.js.

Running TestCafe with `--remote-debugging-port` flag breaks video recording. I corrected it.